### PR TITLE
Adjust PBAX_GROUP id and PROC_ERROR_TEMP settings to get OCC running

### DIFF
--- a/swift.xml
+++ b/swift.xml
@@ -20029,7 +20029,7 @@
 	</attribute>
 	<attribute>
 		<id>OPEN_POWER_PROC_ERROR_TEMP_DEG_C</id>
-		<default>5</default>
+		<default>95</default>
 	</attribute>
 	<attribute>
 		<id>OPEN_POWER_PROC_READ_TIMEOUT_SEC</id>
@@ -45575,11 +45575,11 @@
 	</attribute>
 	<attribute>
 		<id>PBAX_CHIPID</id>
-		<default>0</default>
+		<default>1</default>
 	</attribute>
 	<attribute>
 		<id>PBAX_GROUPID</id>
-		<default>1</default>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>POSITION</id>


### PR DESCRIPTION
The OCC does not support having CHIP_AS_GROUP numbering for PBAX
GROUP/CHIP ids. If you look at Witherspoon they have CHIP_AS_GROUP
set for fabric topology yet they are saying PBAX_GROUP is 0 for both
chips and PBAX_CHIP is 1 for proc1. As we know this works in wither-
spoon system we will follow this in Axone. Also adjust the temp that
we callout the processor to be 95 degrees C instead of 5.