### PR TITLE
Update OBUS1 OPTICS_CONFIG_MODE to be NOT_WIRED for swift

### DIFF
--- a/swift.xml
+++ b/swift.xml
@@ -3501,6 +3501,10 @@
 		<name>OCAPI</name>
 		<value>0x3</value>
 		</enumerator>
+        <enumerator>
+        <name>NOT_WIRED</name>
+        <value>0x4</value>
+        </enumerator>
 </enumerationType>
 <enumerationType>
 	<id>PAYLOAD_KIND</id>
@@ -37788,7 +37792,7 @@
 	</attribute>
 	<attribute>
 		<id>OPTICS_CONFIG_MODE</id>
-		<default>NV</default>
+		<default>NOT_WIRED</default>
 	</attribute>
 	<attribute>
 		<id>PEER_TARGET</id>
@@ -37883,7 +37887,7 @@
 	</attribute>
 	<attribute>
 		<id>OPTICS_CONFIG_MODE</id>
-		<default>NV</default>
+		<default>NOT_WIRED</default>
 	</attribute>
 	<attribute>
 		<id>PEER_TARGET</id>
@@ -37978,7 +37982,7 @@
 	</attribute>
 	<attribute>
 		<id>OPTICS_CONFIG_MODE</id>
-		<default>NV</default>
+		<default>NOT_WIRED</default>
 	</attribute>
 	<attribute>
 		<id>PEER_TARGET</id>


### PR DESCRIPTION
In the Swift configuration, OBUS1 is not wired to anything. Having
this set and NV was causing unintended consequences. Recently the
NOT_WIRED enumeration option was added for this attribute so we can
more accurately represent how the system is layed out.