### PR TITLE
Set max memory speed to 2666 and correct TPM target type

### DIFF
--- a/swift.xml
+++ b/swift.xml
@@ -19478,7 +19478,7 @@
 	</attribute>
 	<attribute>
 		<id>MAX_ALLOWED_DIMM_FREQ</id>
-		<default>3200,3200,3200,3200,3200</default>
+		<default>2666,2666,2666,2666,2666</default>
 	</attribute>
 	<attribute>
 		<id>MAX_CHIPLETS_PER_PROC</id>
@@ -98711,7 +98711,7 @@
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
-		<default>TPM</default>
+		<default>NA</default>
 	</attribute>
 </targetInstance>
 <targetInstance>
@@ -98795,7 +98795,7 @@
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
-		<default></default>
+		<default>TPM</default>
 	</attribute>
 </targetInstance>
 <targetInstance>


### PR DESCRIPTION
For now we want to force the max ddr speed to be 2666. Also there
was a problem in how we were naming the TPM target in the MRW. This
commit addresses both of these problems.