### PR TITLE
Update the OMI link connected to Dimm5's OMI_DL_GROUP_POS attribute

### DIFF
--- a/swift.xml
+++ b/swift.xml
@@ -33705,7 +33705,7 @@
 	</attribute>
 	<attribute>
 		<id>OMI_DL_GROUP_POS</id>
-		<default>0xFF</default>
+		<default>0x00</default>
 	</attribute>
 	<attribute>
 		<id>OMI_DL_LN_REV_ENABLE</id>


### PR DESCRIPTION
Somehow this did not get updated when we updated the rest and was
causing OMI training to fail when we attempting to train ddimms
installed in dimm slot 5 on the swift board.