### PR TITLE
Revert the avsbus related changes that caused istep 8.12 fails

### DIFF
--- a/swift.xml
+++ b/swift.xml
@@ -29919,11 +29919,11 @@
 	</attribute>
 	<attribute>
 		<id>VCS_AVSBUS_BUSNUM</id>
-		<default>0</default>
+		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>VCS_AVSBUS_RAIL</id>
-		<default>1</default>
+		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>VCS_I2C_BUSNUM</id>


### PR DESCRIPTION
These changes were added w/o being tested and caused the driver to
fail. Work needs to be done to verify the avsbus paths before we
enable them.